### PR TITLE
[Behat] Switched the broken test to use a real browser

### DIFF
--- a/features/ContentEdit/create_without_draft.feature
+++ b/features/ContentEdit/create_without_draft.feature
@@ -13,7 +13,7 @@ Scenario: Create a folder without a draft
       And I press "Publish"
      Then I am on the View of the Content that was published
 
-@broken
+@javascript
 Scenario: Content validation errors are reported back
     Given that there is a Content Type with any kind of constraints on a Field Definition
       And that I have permission to create content of this type


### PR DESCRIPTION
Switched the failing test to use another driver (a real browser), that sets correct Accept header in the request.

Now the `Content validation errors are reported back` is passing. It was failing because of incompatible `Content-Type` header in the Response -> the logic behind it has been changed in Symfony 4.4.0 (https://github.com/symfony/http-foundation/commit/703f5084a775c652eb806df0f6c973ae1e9b2c5c#diff-41490c7e368e29f813beef0e771110eeR273).

When no Accept header was set it used to return `text/html`, in Symfony 4.4.0 the Content-Type header is `application/x-www-form-urlencoded', which DOMCrawler cannot parse (https://github.com/symfony/dom-crawler/blob/master/Crawler.php#L143).

Using a real browser, which sets the Accept header correctly, makes the response's Content-Type to be appriopriate for further actions.