### PR TITLE
[Behat] Adjusted tests for Enterprise edition

### DIFF
--- a/src/lib/Behat/Context/ContentEditContext.php
+++ b/src/lib/Behat/Context/ContentEditContext.php
@@ -13,6 +13,7 @@ use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\MinkContext;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct;
+use EzSystems\Behat\Core\Environment\EnvironmentConstants;
 
 final class ContentEditContext extends MinkContext implements Context, SnippetAcceptingContext
 {
@@ -119,6 +120,13 @@ final class ContentEditContext extends MinkContext implements Context, SnippetAc
             ),
             'abc'
         );
+
+        if (EnvironmentConstants::isEnterprise()) {
+            // in Enterprise Edition there are Workflow related form fields required
+            $this->fillField('ezplatform_content_forms_content_edit_workflow_name', 'WorkfowName');
+            $this->fillField('ezplatform_content_forms_content_edit_workflow_transition', 'WorkfowTransition');
+            $this->fillField('ezplatform_content_forms_content_edit_workflow_comment', 'WorkfowComment');
+        }
     }
 
     /**


### PR DESCRIPTION
Depends on https://github.com/ezsystems/BehatBundle/pull/115

Failing build: https://travis-ci.com/ezsystems/ezplatform-page-builder/jobs/261541421 ([screenshot](https://res.cloudinary.com/ezplatformtravis/image/upload/v1575018377/screenshots/5de0df8962ec6592334671-vendor_ezsystems_ezplatform-content-forms_features_contentedit_create_without_draft_feature_17_k1p3kw.png))

In Enterprise the form contains additional fields (required), workflow-related:

![obraz](https://user-images.githubusercontent.com/10993858/69872256-35402c00-12b5-11ea-9d0b-988cd5109e19.png)

They were not required previously, because the thing stopping us from sending the form is the HTML validation present in browser - it was not validated when we didn't use a `real` browser but Goutte driver instead.
