### PR TITLE
Fixed FormTypeBasedFieldValueFormMapper unit tests

### DIFF
--- a/src/lib/Tests/FieldType/Mapper/FormTypeBasedFieldValueFormMapperTest.php
+++ b/src/lib/Tests/FieldType/Mapper/FormTypeBasedFieldValueFormMapperTest.php
@@ -20,6 +20,7 @@ class FormTypeBasedFieldValueFormMapperTest extends BaseMapperTest
         $fieldDefinition = new FieldDefinition([
             'names' => [],
             'isRequired' => false,
+            'fieldTypeIdentifier' => 'ezselection',
             'fieldSettings' => ['isMultiple' => false, 'options' => []],
         ]);
 
@@ -45,6 +46,7 @@ class FormTypeBasedFieldValueFormMapperTest extends BaseMapperTest
         $fieldDefinition = new FieldDefinition([
             'names' => ['eng-GB' => 'foo'],
             'isRequired' => false,
+            'fieldTypeIdentifier' => 'ezselection',
             'fieldSettings' => ['isMultiple' => false, 'options' => []],
         ]);
         $this->data->expects($this->once())


### PR DESCRIPTION
> JIRA: -

## Description

Fixed FormTypeBasedFieldValueFormMapperunit tests

```
/var/www/html/vendor/ezsystems/ezplatform-content-forms $ git checkout origin/master
Previous HEAD position was 1065a58 EZP-30639: Used Content view instead of deprecated Location view
HEAD is now at 0a984ee Merge pull request #7 from webhdx/repoforms_bc
/var/www/html/vendor/ezsystems/ezplatform-content-forms $ php bin/phpunit
PHPUnit 8.5.2 by Sebastian Bergmann and contributors.
....................................................EE........... 65 / 78 ( 83%)
.............                                                     78 / 78 (100%)
Time: 105 ms, Memory: 8.00 MB
There were 2 errors:
1) EzSystems\EzPlatformContentForms\Tests\FieldType\Mapper\FormTypeBasedFieldValueFormMapperTest::testMapFieldValueFormNoLanguageCode
TypeError: Argument 1 passed to Mock_FieldTypeService_452d07bc::getFieldType() must be of the type string, null given, called in /var/www/html/vendor/ezsystems/ezplatform-content-forms/src/lib/FieldType/Mapper/FormTypeBasedFieldValueFormMapper.php on line 79
/var/www/html/vendor/ezsystems/ezplatform-content-forms/src/lib/FieldType/Mapper/FormTypeBasedFieldValueFormMapper.php:79
/var/www/html/vendor/ezsystems/ezplatform-content-forms/src/lib/Tests/FieldType/Mapper/FormTypeBasedFieldValueFormMapperTest.php:38
2) EzSystems\EzPlatformContentForms\Tests\FieldType\Mapper\FormTypeBasedFieldValueFormMapperTest::testMapFieldValueFormWithLanguageCode
TypeError: Argument 1 passed to Mock_FieldTypeService_452d07bc::getFieldType() must be of the type string, null given, called in /var/www/html/vendor/ezsystems/ezplatform-content-forms/src/lib/FieldType/Mapper/FormTypeBasedFieldValueFormMapper.php on line 79
/var/www/html/vendor/ezsystems/ezplatform-content-forms/src/lib/FieldType/Mapper/FormTypeBasedFieldValueFormMapper.php:79
/var/www/html/vendor/ezsystems/ezplatform-content-forms/src/lib/Tests/FieldType/Mapper/FormTypeBasedFieldValueFormMapperTest.php:60
```