### PR TITLE
EZP-31118: Introduced strict types for ContentService

### DIFF
--- a/src/lib/Content/View/Filter/ContentEditViewFilter.php
+++ b/src/lib/Content/View/Filter/ContentEditViewFilter.php
@@ -75,9 +75,9 @@ class ContentEditViewFilter implements EventSubscriberInterface
         $request = $event->getRequest();
         $languageCode = $request->attributes->get('language');
         $contentDraft = $this->contentService->loadContent(
-            $request->attributes->has('contentId') ? $request->attributes->getInt('contentId') : null,
+            $request->attributes->getInt('contentId'),
             [$languageCode], // @todo: rename to languageCode in 3.0
-            $request->attributes->has('versionNo') ? $request->attributes->getInt('versionNo') : null
+            $request->attributes->getInt('versionNo')
         );
 
         $contentType = $this->contentTypeService->loadContentType(

--- a/src/lib/Content/View/Filter/ContentEditViewFilter.php
+++ b/src/lib/Content/View/Filter/ContentEditViewFilter.php
@@ -75,9 +75,9 @@ class ContentEditViewFilter implements EventSubscriberInterface
         $request = $event->getRequest();
         $languageCode = $request->attributes->get('language');
         $contentDraft = $this->contentService->loadContent(
-            $request->attributes->get('contentId'),
+            $request->attributes->has('contentId') ? $request->attributes->getInt('contentId') : null,
             [$languageCode], // @todo: rename to languageCode in 3.0
-            $request->attributes->get('versionNo')
+            $request->attributes->has('versionNo') ? $request->attributes->getInt('versionNo') : null
         );
 
         $contentType = $this->contentTypeService->loadContentType(


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31118](https://jira.ez.no/browse/EZP-31118)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** |  `master`
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | yes

Fixed issues reported in https://github.com/ezsystems/ezpublish-kernel/pull/2866

https://github.com/ezsystems/ezplatform-content-forms/commit/05f424847d8375bfed98c177653f2ec672b436ff

```
Argument 1 passed to eZ\Publish\Core\Repository\SiteAccessAware\ContentService::loadContent() must be of the type int, string given, called in /src/lib/Content/View/Filter/ContentEditViewFilter.php on line 80
```