### PR TITLE
EZP-31007: Replaced ezpublish-kernel with ezplatform-kernel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "jms/translation-bundle": "^1.5"
     },
     "require-dev": {
+        "ezsystems/doctrine-dbal-schema": "^1.0@dev",
         "phpunit/phpunit": "^8.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "behat/behat": "^3.5",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "type": "ezplatform-bundle",
     "require": {
         "php": "^7.3",
-        "ezsystems/ezpublish-kernel": "^8.0@dev",
+        "ezsystems/ezplatform-kernel": "^1.0@dev",
         "symfony/dependency-injection": "^5.0",
         "symfony/http-kernel": "^5.0",
         "symfony/http-foundation": "^5.0",


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31007](https://jira.ez.no/browse/EZP-31007)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.0.0`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

This PR replaces `ezpublish-kernel` with `ezplatform-kernel` and fixes dependency issues blocking package installation (due to Composer minimum stability requirements):

- `ezsystems/doctrine-dbal-schema:^1.0@dev` is required  by `ezplatform-kernel:^1.0@dev`.

#### TODO
- [x] Wait for Travis