### PR TITLE
Add missing translation file

### DIFF
--- a/src/bundle/Resources/translations/ezplatform_fields_groups.en.xliff
+++ b/src/bundle/Resources/translations/ezplatform_fields_groups.en.xliff
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
+  <file source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <header>
+      <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
+      <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
+    </header>
+    <body>
+      <trans-unit id="040f06fd774092478d450774f5ba30c5da78acc8" resname="content">
+        <source>Content</source>
+        <target>Content</target>
+        <note>key: content</note>
+      </trans-unit>
+      <trans-unit id="4c24b2612e94e2ae622e54397663f2b7bf0a2e17" resname="metadata">
+        <source>Metadata</source>
+        <target>Metadata</target>
+        <note>key: metadata</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
This translation was part of `ezsystems/repository-forms`. Without it, admin UI reports missing translation strings.

![image](https://user-images.githubusercontent.com/362286/78225723-f6bcb700-74ca-11ea-91e9-feeb2f64e5dc.png)
