### PR TITLE
EZP-31344: Added grouped form fields for content create/edit

### DIFF
--- a/src/lib/Content/View/Builder/AbstractContentViewBuilder.php
+++ b/src/lib/Content/View/Builder/AbstractContentViewBuilder.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformContentForms\Content\View\Builder;
+
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Values\Content\Language;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\Helper\FieldsGroups\FieldsGroupsList;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
+use eZ\Publish\Core\MVC\Symfony\View\Configurator;
+use eZ\Publish\Core\MVC\Symfony\View\ParametersInjector;
+use EzSystems\EzPlatformContentForms\Form\ActionDispatcher\ActionDispatcherInterface;
+use Symfony\Component\Form\Form;
+
+/*
+ * @internal
+ */
+abstract class AbstractContentViewBuilder
+{
+    /** @var \eZ\Publish\API\Repository\Repository */
+    protected $repository;
+
+    /** @var \eZ\Publish\Core\MVC\Symfony\View\Configurator */
+    protected $viewConfigurator;
+
+    /** @var \eZ\Publish\Core\MVC\Symfony\View\ParametersInjector */
+    protected $viewParametersInjector;
+
+    /** @var \EzSystems\EzPlatformContentForms\Form\ActionDispatcher\ActionDispatcherInterface */
+    protected $contentActionDispatcher;
+
+    /** @var \eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface */
+    protected $languagePreferenceProvider;
+
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    protected $configResolver;
+
+    /** @var \eZ\Publish\Core\Helper\FieldsGroups\FieldsGroupsList */
+    private $fieldsGroupsList;
+
+    public function __construct(
+        Repository $repository,
+        Configurator $viewConfigurator,
+        ParametersInjector $viewParametersInjector,
+        ActionDispatcherInterface $contentActionDispatcher,
+        UserLanguagePreferenceProviderInterface $languagePreferenceProvider,
+        ConfigResolverInterface $configResolver,
+        FieldsGroupsList $fieldsGroupsList
+    ) {
+        $this->repository = $repository;
+        $this->viewConfigurator = $viewConfigurator;
+        $this->viewParametersInjector = $viewParametersInjector;
+        $this->contentActionDispatcher = $contentActionDispatcher;
+        $this->languagePreferenceProvider = $languagePreferenceProvider;
+        $this->configResolver = $configResolver;
+        $this->fieldsGroupsList = $fieldsGroupsList;
+    }
+
+    /**
+     * Loads a visible Location.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    protected function loadLocation(int $locationId): Location
+    {
+        return $this->repository->getLocationService()->loadLocation($locationId);
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    private function loadLanguage(string $languageCode): Language
+    {
+        return $this->repository->getContentLanguageService()->loadLanguage($languageCode);
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    protected function resolveLanguage(array $parameters): Language
+    {
+        if (isset($parameters['languageCode'])) {
+            return $this->loadLanguage($parameters['languageCode']);
+        }
+
+        if (isset($parameters['language'])) {
+            if (is_string($parameters['language'])) {
+                // @todo BC: route parameter should be called languageCode but it won't happen until 3.0
+                return $this->loadLanguage($parameters['language']);
+            }
+
+            return $parameters['language'];
+        }
+
+        throw new InvalidArgumentException('Language',
+            'No language information provided. Are you missing language or languageCode parameters?');
+    }
+
+    protected function getGroupedFields(Form $form): array
+    {
+        $fieldsDataForm = $form->get('fieldsData');
+        $groupedFields = [];
+
+        /** @var \Symfony\Component\Form\Form $fieldForm */
+        foreach ($fieldsDataForm as $fieldForm) {
+            /** @var \EzSystems\EzPlatformContentForms\Data\Content\FieldData $fieldData */
+            $fieldData = $fieldForm->getViewData();
+
+            $fieldGroup = $this->fieldsGroupsList->getFieldGroupTranslated(
+                $fieldData->fieldDefinition
+            );
+
+            $groupedFields[$fieldGroup][] = $fieldForm->getName();
+        }
+
+        return $groupedFields;
+    }
+}

--- a/src/lib/Content/View/Builder/ContentCreateViewBuilder.php
+++ b/src/lib/Content/View/Builder/ContentCreateViewBuilder.php
@@ -8,61 +8,20 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformContentForms\Content\View\Builder;
 
-use eZ\Publish\API\Repository\Repository;
-use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
-use eZ\Publish\Core\MVC\ConfigResolverInterface;
-use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
 use eZ\Publish\Core\MVC\Symfony\View\Builder\ViewBuilder;
-use eZ\Publish\Core\MVC\Symfony\View\Configurator;
-use eZ\Publish\Core\MVC\Symfony\View\ParametersInjector;
 use EzSystems\EzPlatformContentForms\Content\View\ContentCreateSuccessView;
 use EzSystems\EzPlatformContentForms\Content\View\ContentCreateView;
-use EzSystems\EzPlatformContentForms\Form\ActionDispatcher\ActionDispatcherInterface;
 
 /**
  * Builds ContentCreateView objects.
  *
  * @internal
  */
-class ContentCreateViewBuilder implements ViewBuilder
+class ContentCreateViewBuilder extends AbstractContentViewBuilder implements ViewBuilder
 {
-    /** @var \eZ\Publish\API\Repository\Repository */
-    private $repository;
-
-    /** @var \eZ\Publish\Core\MVC\Symfony\View\Configurator */
-    private $viewConfigurator;
-
-    /** @var \eZ\Publish\Core\MVC\Symfony\View\ParametersInjector */
-    private $viewParametersInjector;
-
-    /** @var ActionDispatcherInterface */
-    private $contentActionDispatcher;
-
-    /** @var \eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface */
-    private $languagePreferenceProvider;
-
-    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
-    private $configResolver;
-
-    public function __construct(
-        Repository $repository,
-        Configurator $viewConfigurator,
-        ParametersInjector $viewParametersInjector,
-        ActionDispatcherInterface $contentActionDispatcher,
-        UserLanguagePreferenceProviderInterface $languagePreferenceProvider,
-        ConfigResolverInterface $configResolver
-    ) {
-        $this->repository = $repository;
-        $this->viewConfigurator = $viewConfigurator;
-        $this->viewParametersInjector = $viewParametersInjector;
-        $this->contentActionDispatcher = $contentActionDispatcher;
-        $this->languagePreferenceProvider = $languagePreferenceProvider;
-        $this->configResolver = $configResolver;
-    }
-
     public function matches($argument)
     {
         return 'ez_content_edit:createWithoutDraftAction' === $argument;
@@ -84,6 +43,7 @@ class ContentCreateViewBuilder implements ViewBuilder
         $language = $this->resolveLanguage($parameters);
         $location = $this->resolveLocation($parameters);
         $contentType = $this->resolveContentType($parameters, $this->languagePreferenceProvider->getPreferredLanguages());
+        /** @var \Symfony\Component\Form\Form $form */
         $form = $parameters['form'];
 
         if ($form->isSubmitted() && $form->isValid() && null !== $form->getClickedButton()) {
@@ -112,41 +72,13 @@ class ContentCreateViewBuilder implements ViewBuilder
             'language' => $language,
             'parent_location' => $location,
             'form' => $form->createView(),
+            'grouped_fields' => $this->getGroupedFields($form),
         ]);
 
         $this->viewParametersInjector->injectViewParameters($view, $parameters);
         $this->viewConfigurator->configure($view);
 
         return $view;
-    }
-
-    /**
-     * Loads a visible Location.
-     *
-     * @param int $locationId
-     *
-     * @return \eZ\Publish\API\Repository\Values\Content\Location
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     */
-    private function loadLocation(int $locationId): Location
-    {
-        return $this->repository->getLocationService()->loadLocation($locationId);
-    }
-
-    /**
-     * Loads Language with code $languageCode.
-     *
-     * @param string $languageCode
-     *
-     * @return \eZ\Publish\API\Repository\Values\Content\Language
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     */
-    private function loadLanguage(string $languageCode): Language
-    {
-        return $this->repository->getContentLanguageService()->loadLanguage($languageCode);
     }
 
     /**
@@ -165,33 +97,6 @@ class ContentCreateViewBuilder implements ViewBuilder
             $contentTypeIdentifier,
             $prioritizedLanguages
         );
-    }
-
-    /**
-     * @param array $parameters
-     *
-     * @return \eZ\Publish\API\Repository\Values\Content\Language
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     */
-    private function resolveLanguage(array $parameters): Language
-    {
-        if (isset($parameters['languageCode'])) {
-            return $this->loadLanguage($parameters['languageCode']);
-        }
-
-        if (isset($parameters['language'])) {
-            if (is_string($parameters['language'])) {
-                // @todo BC: route parameter should be called languageCode but it won't happen until 3.0
-                return $this->loadLanguage($parameters['language']);
-            }
-
-            return $parameters['language'];
-        }
-
-        throw new InvalidArgumentException('Language',
-            'No language information provided. Are you missing language or languageCode parameters?');
     }
 
     /**


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-31344
Depends on https://github.com/ezsystems/ezplatform-kernel/pull/73 - **! Please merge it first !**

Added front parameter 'grouped_fields' for content create or edit view. This key contains grouped by category (assigned for fields in some FieldType) fields. Array contains groups names as first-level key, and the related form fields identifiers as a second level array.

```
array:2 [▼
  "content" => array:7 [▼
    0 => "title"
    1 => "short_title"
    2 => "intro"
    3 => "body"
    4 => "enable_comments"
    5 => "image"
    6 => "new_ezdatetime_8"
  ]
  "metadata" => array:1 [▼
    0 => "author"
  ]
]
```