### PR TITLE
[Travis] Switched to using default Docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ matrix:
       php: 7.3
       env:
         - BEHAT_OPTS="--mode=behat --profile=content-forms --tags=~@broken --non-strict"
-        - PHP_IMAGE=ezsystems/php:7.3-v1
 
 # test only master (+ Pull requests)
 branches:


### PR DESCRIPTION
Failing build: https://travis-ci.com/github/ezsystems/ezplatform-content-forms/jobs/375622416

Error:
```
install_dependencies_1  | Executing script yarn install [KO]
install_dependencies_1  |  [KO]
install_dependencies_1  | Script yarn install returned with error code 127
install_dependencies_1  | !!  sh: 1: yarn: not found
install_dependencies_1  | !!  
```

The `ezsystems/php:7.3-v1` image does not contain Node - when not specified the default will be used: https://github.com/ezsystems/ezplatform/blob/3.1/.env#L13 on which everything should be ok.
