### PR TITLE
EZP-31954: fix fatal error when no error target defined

### DIFF
--- a/src/lib/Validator/Constraints/FieldValueValidator.php
+++ b/src/lib/Validator/Constraints/FieldValueValidator.php
@@ -13,8 +13,8 @@ use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\Core\FieldType\ValidationError;
 use eZ\Publish\SPI\FieldType\Value;
 use EzSystems\EzPlatformContentForms\Data\Content\FieldData;
-use Symfony\Component\Validator\Util\PropertyPath;
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Util\PropertyPath;
 
 /**
  * Base class for field value validators.
@@ -89,6 +89,10 @@ class FieldValueValidator extends FieldTypeValidator
 
     protected function generatePropertyPath($errorIndex, $errorTarget): string
     {
-        return PropertyPath::append('value', $errorTarget);
+        $basePath = 'value';
+
+        return $errorTarget === null
+            ? $basePath
+            : PropertyPath::append($basePath, $errorTarget);
     }
 }


### PR DESCRIPTION
**JIRA**: https://jira.ez.no/browse/EZP-31954

In case of RichText XML validation fails, fatal error displayed:

> Argument 2 passed to Symfony\Component\Validator\Util\PropertyPath::append() must be of the type string, null given, called in /app/vendor/ezsystems/ezplatform-content-forms/src/lib/Validator/Constraints/FieldValueValidator.php on line 92 [in vendor/symfony/validator/Util/PropertyPath.php:34]

related PR: https://github.com/ezsystems/ezplatform-richtext/pull/164