### PR TITLE
IBX-219: Fixed missing float value in edit view after changing BO language

### DIFF
--- a/src/lib/Form/Type/FieldType/FloatFieldType.php
+++ b/src/lib/Form/Type/FieldType/FloatFieldType.php
@@ -48,6 +48,8 @@ class FloatFieldType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->addModelTransformer(new FieldValueTransformer($this->fieldTypeService->getFieldType('ezfloat')));
+        // Removes NumberToLocalizedStringTransformer which breaks "number" type HTML input
+        $builder->resetViewTransformers();
     }
 
     public function buildView(FormView $view, FormInterface $form, array $options)


### PR DESCRIPTION
JIRA ticket: https://issues.ibexa.co/browse/IBX-219

The same problem surfaced quite some time ago in v2, ref: https://github.com/ezsystems/repository-forms/pull/325. After moving code from `repository-forms` to `ezplatform-content-forms` the line proposed in this PR got lost somehow. 

Therefore, changing the locale results in unwanted `NumberToLocalizedStringTransformer::transform` call kicking in and wrongly parsing float values (`3.5` -> `3,5`). Due to this operation, the `ezfloat` form is not able to render comma-separated value properly and editors end up with empty input.