### PR TITLE
Fixed Behat tests

### DIFF
--- a/behat_suites.yml
+++ b/behat_suites.yml
@@ -9,7 +9,6 @@ content-forms:
                 - EzSystems\EzPlatformContentForms\Behat\Context\ContentEditContext
                 - EzSystems\EzPlatformContentForms\Behat\Context\ContentTypeContext
                 - EzSystems\EzPlatformContentForms\Behat\Context\PagelayoutContext
-                - EzSystems\Behat\Browser\Context\Hooks
         fieldtype_form:
             paths:
                 - vendor/ezsystems/ezplatform-content-forms/features/FieldTypeForm
@@ -24,4 +23,3 @@ content-forms:
                 - EzSystems\EzPlatformContentForms\Behat\Context\UserRegistrationContext
                 - Behat\MinkExtension\Context\MinkContext
                 - eZ\Bundle\EzPublishCoreBundle\Features\Context\YamlConfigurationContext
-                - EzSystems\Behat\Browser\Context\Hooks

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     "require-dev": {
         "ibexa/ci-scripts": "^0.1@dev",
         "ezsystems/doctrine-dbal-schema": "^1.0@dev",
+        "ezsystems/behatbundle": "^8.3@dev",
         "phpunit/phpunit": "^8.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "behat/behat": "^3.5",
@@ -49,6 +50,6 @@
         }
     },
     "scripts": {
-        "fix-cs": "@php ./bin/php-cs-fixer fix -v --show-progress=estimating"
+        "fix-cs": "php-cs-fixer fix -v --show-progress=estimating"
     }
 }

--- a/src/lib/Behat/Context/ContentEditContext.php
+++ b/src/lib/Behat/Context/ContentEditContext.php
@@ -13,7 +13,6 @@ use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\MinkContext;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct;
-use EzSystems\Behat\Core\Environment\EnvironmentConstants;
 
 final class ContentEditContext extends MinkContext implements Context, SnippetAcceptingContext
 {
@@ -121,7 +120,7 @@ final class ContentEditContext extends MinkContext implements Context, SnippetAc
             'abc'
         );
 
-        if (EnvironmentConstants::isEnterprise()) {
+        if ($this->getSession()->getPage()->hasField('ezplatform_content_forms_content_edit_workflow_name')) {
             // in Enterprise Edition there are Workflow related form fields required
             $this->fillField('ezplatform_content_forms_content_edit_workflow_name', 'WorkfowName');
             $this->fillField('ezplatform_content_forms_content_edit_workflow_transition', 'WorkfowTransition');

--- a/src/lib/Behat/Context/FieldTypeFormContext.php
+++ b/src/lib/Behat/Context/FieldTypeFormContext.php
@@ -150,11 +150,11 @@ final class FieldTypeFormContext extends RawMinkContext implements SnippetAccept
             $inputId = $inputElement->getAttribute('id');
             $label = $this->getSession()->getPage()->find('css', sprintf('label[for=%s]', $inputId))->getText();
 
-            $actualInputFields[] = ['type' => $type, 'label' => $label];
+            $actualInputFields[] = ['label' => $label, 'type' => $type];
         }
 
-        foreach ($expectedInputFields = $table->getColumnsHash() as $inputField) {
-            Assertion::assertContains($inputField, $actualInputFields);
+        foreach ($table->getColumnsHash() as $expectedField) {
+            Assertion::assertContains($expectedField, $actualInputFields);
         }
     }
 

--- a/src/lib/Behat/Context/PagelayoutContext.php
+++ b/src/lib/Behat/Context/PagelayoutContext.php
@@ -12,8 +12,6 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\MinkExtension\Context\RawMinkContext;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
-use EzSystems\Behat\Core\Environment\EnvironmentConstants;
-use EzSystems\Behat\Core\Environment\InstallType;
 use PHPUnit\Framework\Assert as Assertion;
 
 class PagelayoutContext extends RawMinkContext implements Context, SnippetAcceptingContext
@@ -52,20 +50,8 @@ class PagelayoutContext extends RawMinkContext implements Context, SnippetAccept
 
     public function getPageLayout(): string
     {
-        $installType = EnvironmentConstants::getInstallType();
-        switch ($installType) {
-            case InstallType::PLATFORM:
-            case InstallType::ENTERPRISE:
-                return $this->configResolver->hasParameter('page_layout')
-                    ? $this->configResolver->getParameter('page_layout', null, 'site')
-                    : $this->configResolver->getParameter('pagelayout', null, 'site');
-            case InstallType::PLATFORM_DEMO:
-            case InstallType::ENTERPRISE_DEMO:
-                return $this->configResolver->hasParameter('page_layout')
-                    ? str_replace('@ezdesign', 'templates/themes/tastefulplanet', $this->configResolver->getParameter('page_layout', null, 'site'))
-                    : str_replace('@ezdesign', 'templates/themes/tastefulplanet', $this->configResolver->getParameter('pagelayout', null, 'site'));
-            default:
-                throw new \Exception('Unrecognised installation type');
-        }
+        return $this->configResolver->hasParameter('page_layout')
+                ? $this->configResolver->getParameter('page_layout', null, 'site')
+                : $this->configResolver->getParameter('pagelayout', null, 'site');
     }
 }

--- a/src/lib/Behat/Context/UserRegistrationContext.php
+++ b/src/lib/Behat/Context/UserRegistrationContext.php
@@ -23,7 +23,6 @@ use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\API\Repository\Values\User\UserGroup;
 use eZ\Publish\Core\Repository\Values\User\RoleCreateStruct;
 use eZ\Publish\Core\Repository\Values\User\UserReference;
-use EzSystems\Behat\Core\Environment\EnvironmentConstants;
 use PHPUnit\Framework\Assert as Assertion;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Yaml\Yaml;
@@ -158,7 +157,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
 
         $roleCreateStruct = new RoleCreateStruct(['identifier' => $roleIdentifier]);
 
-        $policiesSet = explode(',', EnvironmentConstants::get('CREATE_REGISTRATION_ROLE_POLICIES'));
+        $policiesSet = ['user/login', 'content/read'];
         foreach ($policiesSet as $policy) {
             [$module, $function] = explode('/', $policy);
             $roleCreateStruct->addPolicy($this->roleService->newPolicyCreateStruct($module, $function));
@@ -275,7 +274,7 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
      */
     public function iSeeARegistrationConfirmationMessage()
     {
-        $this->assertSession()->pageTextContains(EnvironmentConstants::get('REGISTRATION_CONFIRMATION_MESSAGE'));
+        $this->assertSession()->pageTextContains('Your account has been created');
     }
 
     /**


### PR DESCRIPTION
Adapted tests to the refactoring done in BehatBundle recently.

Needed for green build in https://github.com/ezsystems/ezplatform-content-forms/pull/46

Things done:
1) Removed unused Context classes
2) Removed `EnvironmentConstants` class usage - it's main purpose was to have the tests passing on Demo, but we don't tests on Demo anymore. This allows us to simplify this code.