### PR TITLE
[Behat] Split User Registration tests into setup and execution features

### DIFF
--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -14,6 +14,7 @@ jobs:
         with:
             project-edition: 'oss'
             project-version: '^3.3.x-dev'
-            test-suite:  '--mode=behat --profile=content-forms --tags=~@broken --non-strict'
+            test-suite:  '--mode=standard --profile=content-forms --tags=~@broken --non-strict'
+            test-setup-phase-1: '--mode=standard --profile=setup-content-forms'
         secrets:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/behat_suites.yml
+++ b/behat_suites.yml
@@ -1,5 +1,15 @@
 # This file is meant to be imported from ezplatform's behat.yml.dist.
 # All path are relative to the root ezplatform directory.
+
+setup-content-forms:
+    suites:
+        setup:
+            paths:
+                - vendor/ezsystems/ezplatform-content-forms/features/User/Setup
+            contexts:
+                - EzSystems\EzPlatformContentForms\Behat\Context\UserRegistrationContext
+                - eZ\Bundle\EzPublishCoreBundle\Features\Context\YamlConfigurationContext
+
 content-forms:
     suites:
         content_edit:

--- a/features/User/Registration/user_registration.feature
+++ b/features/User/Registration/user_registration.feature
@@ -18,20 +18,8 @@ Scenario: A new user account can be registered from "/register"
       And the user account has been created
 
 Scenario: The user group where registered users are created can be customized
-    Given a User Group
-      And the following user registration group configuration:
-      """
-      ezpublish:
-        system:
-          default:
-            user_registration:
-              group_id: <userGroupContentId>
-          site_group:
-            user_registration:
-              group_id: <userGroupContentId>
-      """
      When I register a user account
-     Then the user is created in this user group
+     Then the user is created in  "TestUserGroup" user group
 
 @broken
 Scenario: The user registration templates can be customized

--- a/features/User/Setup/setup.feature
+++ b/features/User/Setup/setup.feature
@@ -1,0 +1,18 @@
+Feature: User registration form setup
+    In order to allow users to create an account on a site
+    As a site owner
+    I want to expose a user registration form
+
+    Scenario: The user group where registered users are created can be customized
+        Given a User Group "TestUserGroup"
+        And the following user registration group configuration:
+        """
+        ezpublish:
+            system:
+                default:
+                    user_registration:
+                        group_id: <userGroupContentId>
+                site_group:
+                    user_registration:
+                        group_id: <userGroupContentId>
+        """

--- a/src/lib/Behat/Context/UserRegistrationContext.php
+++ b/src/lib/Behat/Context/UserRegistrationContext.php
@@ -286,12 +286,12 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     }
 
     /**
-     * @Given /^a User Group$/
+     * @Given a User Group :userGroupName
      */
-    public function createUserGroup()
+    public function createUserGroup(string $userGroupName)
     {
         $groupCreateStruct = $this->userService->newUserGroupCreateStruct(self::$language);
-        $groupCreateStruct->setField('name', uniqid('User registration group ', true));
+        $groupCreateStruct->setField('name', $userGroupName);
         $this->customUserGroup = $this->userService->createUserGroup(
             $groupCreateStruct,
             $this->userService->loadUserGroup(self::$groupId)
@@ -327,16 +327,16 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     }
 
     /**
-     * @Then /^the user is created in this user group$/
+     * @Then /^the user is created in :userGroupName user group$/
      */
-    public function theUserIsCreatedInThisUserGroup()
+    public function theUserIsCreatedInThisUserGroup(string $userGroupName)
     {
         $user = $this->userService->loadUserByLogin($this->registrationUsername);
         $userGroups = $this->userService->loadUserGroupsOfUser($user);
 
         Assertion::assertEquals(
-            $this->customUserGroup->id,
-            $userGroups[0]->id
+            $userGroupName,
+            $userGroups[0]->getName()
         );
     }
 


### PR DESCRIPTION
The builds for 1.3 and higher branches are failing:
https://github.com/ezsystems/ezplatform-content-forms/runs/6076516291?check_suite_focus=true
```
     Then the user is created in this user group                                 # EzSystems\EzPlatformContentForms\Behat\Context\UserRegistrationContext::theUserIsCreatedInThisUserGroup()
      Failed asserting that 11 matches expected 56.
```

This is a similar case as in https://github.com/ezsystems/ezplatform-kernel/pull/297 - the tests are clearing cache when they're running and for some reason it fails.

I've decided to go with the same solution as in the PR above - the Scenario is split into two (one sets up the tests and the other performs all the other actions).