### PR TITLE
IBX-3265: Fixed translation of User content objects

### DIFF
--- a/src/bundle/Controller/UserController.php
+++ b/src/bundle/Controller/UserController.php
@@ -170,7 +170,7 @@ class UserController extends Controller
         string $language,
         Request $request
     ) {
-        $user = $this->userService->loadUser($contentId);
+        $user = $this->userService->loadUser($contentId, [$language]);
         if (!$this->permissionResolver->canUser('content', 'edit', $user)) {
             throw new CoreUnauthorizedException('content', 'edit', ['userId' => $contentId]);
         }

--- a/src/bundle/Resources/config/validation.yaml
+++ b/src/bundle/Resources/config/validation.yaml
@@ -29,7 +29,3 @@ EzSystems\EzPlatformContentForms\Data\User\UserAccountFieldData:
         username:
             - Valid: ~
             - NotBlank: ~
-
-EzSystems\EzPlatformContentForms\Data\Content\FieldData:
-    constraints:
-        - EzSystems\EzPlatformContentForms\Validator\Constraints\FieldValue: ~

--- a/src/lib/Form/Processor/User/UserUpdateFormProcessor.php
+++ b/src/lib/Form/Processor/User/UserUpdateFormProcessor.php
@@ -81,6 +81,14 @@ class UserUpdateFormProcessor implements EventSubscriberInterface
         $data->contentUpdateStruct = $this->contentService->newContentUpdateStruct();
 
         foreach ($data->fieldsData as $fieldDefIdentifier => $fieldData) {
+            if (
+                !$fieldData->fieldDefinition->isTranslatable
+                && $data->user->contentInfo->mainLanguageCode !== $languageCode
+            ) {
+                // Skip updating not translatable fields when editing not main language
+
+                continue;
+            }
             $data->contentUpdateStruct->setField($fieldDefIdentifier, $fieldData->value, $languageCode);
         }
     }

--- a/src/lib/Form/Type/Content/BaseContentType.php
+++ b/src/lib/Form/Type/Content/BaseContentType.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformContentForms\Form\Type\Content;
 
+use EzSystems\EzPlatformContentForms\Validator\Constraints\FieldValue;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -42,6 +43,9 @@ class BaseContentType extends AbstractType
                     'content' => $options['content'] ?? null,
                     'contentCreateStruct' => $options['contentCreateStruct'] ?? null,
                     'contentUpdateStruct' => $options['contentUpdateStruct'] ?? null,
+                    'constraints' => [
+                        new FieldValue(null, null, ['intent' => $options['intent']]),
+                    ],
                 ],
             ])
             ->add('redirectUrlAfterPublish', HiddenType::class, [
@@ -59,7 +63,12 @@ class BaseContentType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver
-            ->setDefaults(['translation_domain' => 'ezplatform_content_forms_content'])
+            ->setDefined(['intent'])
+            ->setAllowedTypes('intent', 'string')
+            ->setDefaults([
+                'translation_domain' => 'ezplatform_content_forms_content',
+                'intent' => 'update',
+            ])
             ->setRequired(['languageCode', 'mainLanguageCode']);
     }
 }

--- a/src/lib/Form/Type/Content/ContentEditType.php
+++ b/src/lib/Form/Type/Content/ContentEditType.php
@@ -68,6 +68,9 @@ class ContentEditType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver
+            ->setDefined(['intent'])
+            ->setAllowedTypes('intent', 'string')
+            ->setAllowedValues('intent', ['register', 'update', 'create', 'translate'])
             ->setDefaults([
                 'content' => null,
                 'contentCreateStruct' => null,

--- a/src/lib/Form/Type/FieldType/UserAccountFieldType.php
+++ b/src/lib/Form/Type/FieldType/UserAccountFieldType.php
@@ -67,6 +67,6 @@ class UserAccountFieldType extends AbstractType
                 'translation_domain' => 'ezplatform_content_forms_fieldtype',
             ])
             ->setRequired(['intent'])
-            ->setAllowedValues('intent', ['register', 'create', 'update']);
+            ->setAllowedValues('intent', ['register', 'create', 'update', 'translate']);
     }
 }

--- a/src/lib/Validator/Constraints/FieldValueValidator.php
+++ b/src/lib/Validator/Constraints/FieldValueValidator.php
@@ -42,6 +42,18 @@ class FieldValueValidator extends FieldTypeValidator
         $fieldDefinition = $this->getFieldDefinition($value);
         $fieldType = $this->fieldTypeService->getFieldType($fieldTypeIdentifier);
 
+        if (
+            false === $fieldDefinition->isTranslatable
+            && isset($constraint->payload['intent'])
+            && $constraint->payload['intent'] === 'translate'
+        ) {
+            // In content translation mode and the field is not translatable.
+            // Validation has to be skipped or it'll violate constraints on
+            // some field i.e. ezuser
+
+            return;
+        }
+
         if ($fieldDefinition->isRequired && $fieldType->isEmptyValue($fieldValue)) {
             $validationErrors = [
                 new ValidationError(


### PR DESCRIPTION
> JIRA: https://issues.ibexa.co/browse/IBX-3265
> Requires: https://github.com/ezsystems/ezplatform-admin-ui/pull/2081

Looks like translating User content objects was never working properly. Architecture of Content editing forms is very limiting thus the solution is not perfect. It required a few steps to fix the issue:
- `User` object with incorrect language was passed to `UserUpdateMapper` which prevented displaying an editing form
- `FieldValueValidator` was defined as data constraint which had to be changed to form constraint in order to provide more context to the validator. Intuitively you'd use validation groups here but it isn't possible with how we dynamically map fields. Right now the form will define `FieldValue` constraint with `intent` option passed as payload. Then the validator itself can detect wether it should skip validation on nontranslatable fieldtypes.
- Translation has to use it's own intent. Previously we heavily relied on translations being content updates but it was very limiting in places where you can't access `Content` object to check `mainLanguageCode`. 

