### PR TITLE
IBX-4486: Disabled Autosave feature for `nodraft` requests

### DIFF
--- a/src/lib/Content/View/Filter/ContentCreateViewFilter.php
+++ b/src/lib/Content/View/Filter/ContentCreateViewFilter.php
@@ -87,7 +87,7 @@ class ContentCreateViewFilter implements EventSubscriberInterface
         $form = $this->resolveContentCreateForm(
             $contentCreateData,
             $languageCode,
-            true
+            false
         );
 
         $event->getParameters()->add(['form' => $form->handleRequest($request)]);
@@ -125,14 +125,14 @@ class ContentCreateViewFilter implements EventSubscriberInterface
     private function resolveContentCreateForm(
         ContentCreateData $contentCreateData,
         string $languageCode,
-        bool $autosaveDisabled = false
+        bool $autosaveEnabled = true
     ): FormInterface {
         return $this->formFactory->create(ContentEditType::class, $contentCreateData, [
             'languageCode' => $languageCode,
             'mainLanguageCode' => $languageCode,
             'contentCreateStruct' => $contentCreateData,
             'drafts_enabled' => true,
-            'autosave_disabled' => $autosaveDisabled,
+            'autosave_enabled' => $autosaveEnabled,
         ]);
     }
 }

--- a/src/lib/Content/View/Filter/ContentCreateViewFilter.php
+++ b/src/lib/Content/View/Filter/ContentCreateViewFilter.php
@@ -86,7 +86,8 @@ class ContentCreateViewFilter implements EventSubscriberInterface
         $contentCreateData = $this->resolveContentCreateData($contentType, $location, $languageCode);
         $form = $this->resolveContentCreateForm(
             $contentCreateData,
-            $languageCode
+            $languageCode,
+            true
         );
 
         $event->getParameters()->add(['form' => $form->handleRequest($request)]);
@@ -123,13 +124,15 @@ class ContentCreateViewFilter implements EventSubscriberInterface
      */
     private function resolveContentCreateForm(
         ContentCreateData $contentCreateData,
-        string $languageCode
+        string $languageCode,
+        bool $autosaveDisabled = false
     ): FormInterface {
         return $this->formFactory->create(ContentEditType::class, $contentCreateData, [
             'languageCode' => $languageCode,
             'mainLanguageCode' => $languageCode,
             'contentCreateStruct' => $contentCreateData,
             'drafts_enabled' => true,
+            'autosave_disabled' => $autosaveDisabled,
         ]);
     }
 }

--- a/src/lib/Form/Type/Content/ContentEditType.php
+++ b/src/lib/Form/Type/Content/ContentEditType.php
@@ -43,26 +43,32 @@ class ContentEditType extends AbstractType
         $builder
             ->add('publish', SubmitType::class, ['label' => 'Publish']);
 
-        if ($options['drafts_enabled']) {
-            $builder
-                ->add('saveDraft', SubmitType::class, [
-                    'label' => /** @Desc("Save draft") */ 'save_draft',
-                    'attr' => ['formnovalidate' => 'formnovalidate'],
-                ])
-                ->add('cancel', SubmitType::class, [
-                    'label' => /** @Desc("Cancel") */ 'cancel',
-                    'attr' => ['formnovalidate' => 'formnovalidate'],
-                ])
-                ->add('autosave', SubmitType::class, [
-                    'label' => /** @Desc("Autosave") */ 'autosave',
-                    'attr' => [
-                        'hidden' => true,
-                        'formnovalidate' => 'formnovalidate',
-                    ],
-                    'translation_domain' => 'content_edit',
-                ]);
-            $builder->addEventSubscriber(new SuppressValidationSubscriber());
+        if (!$options['drafts_enabled']) {
+            return;
         }
+
+        $builder
+            ->add('saveDraft', SubmitType::class, [
+                'label' => /** @Desc("Save draft") */ 'save_draft',
+                'attr' => ['formnovalidate' => 'formnovalidate'],
+            ])
+            ->add('cancel', SubmitType::class, [
+                'label' => /** @Desc("Cancel") */ 'cancel',
+                'attr' => ['formnovalidate' => 'formnovalidate'],
+            ]);
+
+        if (!($options['autosave_disabled'] ?? false)) {
+            $builder->add('autosave', SubmitType::class, [
+                'label' => /** @Desc("Autosave") */ 'autosave',
+                'attr' => [
+                    'hidden' => true,
+                    'formnovalidate' => 'formnovalidate',
+                ],
+                'translation_domain' => 'content_edit',
+            ]);
+        }
+
+        $builder->addEventSubscriber(new SuppressValidationSubscriber());
     }
 
     public function configureOptions(OptionsResolver $resolver)
@@ -73,6 +79,7 @@ class ContentEditType extends AbstractType
                 'contentCreateStruct' => null,
                 'contentUpdateStruct' => null,
                 'drafts_enabled' => false,
+                'autosave_disabled' => false,
                 'data_class' => ContentStruct::class,
                 'translation_domain' => 'ezplatform_content_forms_content',
                 'intent' => 'update',

--- a/src/lib/Form/Type/Content/ContentEditType.php
+++ b/src/lib/Form/Type/Content/ContentEditType.php
@@ -57,7 +57,7 @@ class ContentEditType extends AbstractType
                 'attr' => ['formnovalidate' => 'formnovalidate'],
             ]);
 
-        if (!$options['autosave_disabled']) {
+        if ($options['autosave_enabled']) {
             $builder->add('autosave', SubmitType::class, [
                 'label' => /** @Desc("Autosave") */ 'autosave',
                 'attr' => [
@@ -79,7 +79,7 @@ class ContentEditType extends AbstractType
                 'contentCreateStruct' => null,
                 'contentUpdateStruct' => null,
                 'drafts_enabled' => false,
-                'autosave_disabled' => false,
+                'autosave_enabled' => true,
                 'data_class' => ContentStruct::class,
                 'translation_domain' => 'ezplatform_content_forms_content',
                 'intent' => 'update',

--- a/src/lib/Form/Type/Content/ContentEditType.php
+++ b/src/lib/Form/Type/Content/ContentEditType.php
@@ -57,7 +57,7 @@ class ContentEditType extends AbstractType
                 'attr' => ['formnovalidate' => 'formnovalidate'],
             ]);
 
-        if (!($options['autosave_disabled'] ?? false)) {
+        if (!$options['autosave_disabled']) {
             $builder->add('autosave', SubmitType::class, [
                 'label' => /** @Desc("Autosave") */ 'autosave',
                 'attr' => [


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-4486
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Autosave shouldn't be enabled for `nodraft` requests.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
