### PR TITLE
IBX-5465: Fixed filtering empty author fields

### DIFF
--- a/src/lib/Form/Type/FieldType/AuthorFieldType.php
+++ b/src/lib/Form/Type/FieldType/AuthorFieldType.php
@@ -70,7 +70,7 @@ class AuthorFieldType extends AbstractType
         $builder
             ->add('authors', AuthorCollectionType::class, [])
             ->addViewTransformer($this->getViewTransformer())
-            ->addEventListener(FormEvents::POST_SUBMIT, [$this, 'filterOutEmptyAuthors']);
+            ->addEventListener(FormEvents::POST_SET_DATA, [$this, 'filterOutEmptyAuthors']);
     }
 
     /**


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | https://issues.ibexa.co/browse/IBX-5465
| **Type**                                   | bug
| **Target Ibexa version** | `3.3`
| **BC breaks**                          | no
| **Doc needed**                       | no

The problem is that `POST_SUBMIT` event is never fired when the author form is disabled (it can be disabled in case a user doesn't have permission to edit this field due to fieldtype limitation), hence `filterOutEmptyAuthors` is never fired which creates an author entry.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly.
- [x] Asked for a review (pre-reviewed beforehand, same code).