### PR TITLE
IBX-4031: Forced published non-translatable field to be shown in current field

### DIFF
--- a/src/lib/Behat/Context/UserRegistrationContext.php
+++ b/src/lib/Behat/Context/UserRegistrationContext.php
@@ -305,8 +305,8 @@ class UserRegistrationContext extends RawMinkContext implements Context, Snippet
     {
         $extraConfigurationString = str_replace(
             '<userGroupContentId>',
-            $this->customUserGroup->id,
-            $extraConfigurationString
+            (string)$this->customUserGroup->id,
+            $extraConfigurationString->getRaw()
         );
 
         $this->yamlConfigurationContext->addConfiguration(Yaml::parse($extraConfigurationString));

--- a/tests/lib/Data/Mapper/ContentUpdateMapperTest.php
+++ b/tests/lib/Data/Mapper/ContentUpdateMapperTest.php
@@ -21,7 +21,7 @@ use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection;
 use EzSystems\EzPlatformContentForms\Data\Mapper\ContentUpdateMapper;
 use PHPUnit\Framework\TestCase;
 
-class ContentUpdateMapperTest extends TestCase
+final class ContentUpdateMapperTest extends TestCase
 {
     public function testMapToFormData(): void
     {

--- a/tests/lib/Data/Mapper/ContentUpdateMapperTest.php
+++ b/tests/lib/Data/Mapper/ContentUpdateMapperTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\ContentForms\Data\Mapper;
+
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Field as APIField;
+use eZ\Publish\API\Repository\Values\Content\Language;
+use eZ\Publish\API\Repository\Values\Content\Section;
+use eZ\Publish\Core\Repository\Values\Content\Content;
+use eZ\Publish\Core\Repository\Values\Content\Location as APILocation;
+use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
+use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
+use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection;
+use EzSystems\EzPlatformContentForms\Data\Mapper\ContentUpdateMapper;
+use PHPUnit\Framework\TestCase;
+
+class ContentUpdateMapperTest extends TestCase
+{
+    public function testMapToFormData(): void
+    {
+        $currentFields = [
+            new APIField([
+                'fieldDefIdentifier' => 'name',
+                'fieldTypeIdentifier' => 'ezstring',
+                'languageCode' => 'eng-GB',
+                'value' => 'Name',
+            ]),
+            new APIField([
+                'fieldDefIdentifier' => 'short_name',
+                'fieldTypeIdentifier' => 'ezstring',
+                'languageCode' => 'eng-DE',
+                'value' => $expectedShortName = 'Nontranslateable short name',
+            ]),
+        ];
+        $content = new Content([
+            'versionInfo' => new VersionInfo([
+                'contentInfo' => new ContentInfo([
+                    'remoteId' => 'foo',
+                    'mainLanguage' => new Language([
+                        'languageCode' => 'eng-GB',
+                    ]),
+                    'alwaysAvailable' => true,
+                    'sectionId' => 2,
+                    'section' => new Section([
+                        'id' => 2,
+                        'identifier' => 'foo_section_identifier',
+                    ]),
+                    'publishedDate' => new \DateTime('2020-10-30T11:40:09+00:00'),
+                    'modificationDate' => new \DateTime('2020-10-30T11:40:09+00:00'),
+                    'mainLocation' => new APILocation([
+                        'parentLocationId' => 1,
+                        'hidden' => true,
+                        'sortField' => 9,
+                        'sortOrder' => 0,
+                        'priority' => 1,
+                    ]),
+                ]),
+            ]),
+            'contentType' => $contentType = new ContentType([
+                'identifier' => 'folder',
+                'fieldDefinitions' => new FieldDefinitionCollection([
+                    new FieldDefinition([
+                        'identifier' => 'name',
+                        'isTranslatable' => true,
+                        'defaultValue' => '',
+                    ]),
+                    new FieldDefinition([
+                        'identifier' => 'short_name',
+                        'isTranslatable' => false,
+                        'defaultValue' => '',
+                    ]),
+                ]),
+            ]),
+            'internalFields' => [
+                new APIField([
+                    'fieldDefIdentifier' => 'name',
+                    'fieldTypeIdentifier' => 'ezstring',
+                    'languageCode' => 'ger-DE',
+                    'value' => $expectedName = 'GER name',
+                ]),
+                new APIField([
+                    'fieldDefIdentifier' => 'short_name',
+                    'fieldTypeIdentifier' => 'ezstring',
+                    'languageCode' => 'ger-DE',
+                    'value' => '',
+                ]),
+            ],
+        ]);
+
+        $data = (new ContentUpdateMapper())->mapToFormData($content, [
+            'languageCode' => 'ger-DE',
+            'contentType' => $contentType,
+            'currentFields' => $currentFields,
+        ]);
+
+        $fieldsData = $data->fieldsData;
+
+        self::assertSame($expectedName, $fieldsData['name']->value);
+        self::assertSame($expectedShortName, $fieldsData['short_name']->value);
+    }
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-4031](https://issues.ibexa.co/browse/IBX-4031)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Following PR assures that in content edit form there is a 'fresh' value set for fields that are non-translatable. Those values are taken from main published version.

Related PR: https://github.com/ezsystems/ezplatform-kernel/pull/380

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
