### PR TITLE
Added fallback for cases when base value is not set for nontranslatable fields in ContentUpdateMapper

### DIFF
--- a/src/lib/Data/Mapper/ContentUpdateMapper.php
+++ b/src/lib/Data/Mapper/ContentUpdateMapper.php
@@ -45,7 +45,7 @@ class ContentUpdateMapper implements FormDataMapperInterface
             $data->addFieldData(new FieldData([
                 'fieldDefinition' => $fieldDef,
                 'field' => $field,
-                'value' => $isNonTranslatable
+                'value' => $isNonTranslatable && isset($mappedCurrentFields[$fieldDef->identifier])
                     ? $mappedCurrentFields[$fieldDef->identifier]->value
                     : $field->value,
             ]));


### PR DESCRIPTION
Fixes regression from #72. It seems like ContentUpdateMapper was expecting contentFields option to be always set, however it shouldn't be required from BC standpoint.