### PR TITLE
IBX-6495: Fixed saving non-translatable fields in main language

### DIFF
--- a/src/lib/Data/Mapper/ContentUpdateMapper.php
+++ b/src/lib/Data/Mapper/ContentUpdateMapper.php
@@ -38,6 +38,7 @@ class ContentUpdateMapper implements FormDataMapperInterface
         $data->initialLanguageCode = $languageCode;
 
         $fields = $contentDraft->getFieldsByLanguage($languageCode);
+        $mainLanguageCode = $contentDraft->getVersionInfo()->getContentInfo()->getMainLanguage()->getLanguageCode();
 
         foreach ($params['contentType']->fieldDefinitions as $fieldDef) {
             $isNonTranslatable = $fieldDef->isTranslatable === false;
@@ -45,9 +46,11 @@ class ContentUpdateMapper implements FormDataMapperInterface
             $data->addFieldData(new FieldData([
                 'fieldDefinition' => $fieldDef,
                 'field' => $field,
-                'value' => $isNonTranslatable && isset($mappedCurrentFields[$fieldDef->identifier])
-                    ? $mappedCurrentFields[$fieldDef->identifier]->value
-                    : $field->value,
+                'value' => $isNonTranslatable
+                    && isset($mappedCurrentFields[$fieldDef->identifier])
+                    && $mainLanguageCode !== $languageCode
+                        ? $mappedCurrentFields[$fieldDef->identifier]->value
+                        : $field->value,
             ]));
         }
 

--- a/src/lib/Data/Mapper/ContentUpdateMapper.php
+++ b/src/lib/Data/Mapper/ContentUpdateMapper.php
@@ -43,12 +43,13 @@ class ContentUpdateMapper implements FormDataMapperInterface
         foreach ($params['contentType']->fieldDefinitions as $fieldDef) {
             $isNonTranslatable = $fieldDef->isTranslatable === false;
             $field = $fields[$fieldDef->identifier];
+            $shouldUseCurrentFieldValue = $isNonTranslatable
+                && isset($mappedCurrentFields[$fieldDef->identifier])
+                && $mainLanguageCode !== $languageCode;
             $data->addFieldData(new FieldData([
                 'fieldDefinition' => $fieldDef,
                 'field' => $field,
-                'value' => $isNonTranslatable
-                    && isset($mappedCurrentFields[$fieldDef->identifier])
-                    && $mainLanguageCode !== $languageCode
+                'value' => $shouldUseCurrentFieldValue
                         ? $mappedCurrentFields[$fieldDef->identifier]->value
                         : $field->value,
             ]));

--- a/src/lib/Data/Mapper/ContentUpdateMapper.php
+++ b/src/lib/Data/Mapper/ContentUpdateMapper.php
@@ -50,8 +50,8 @@ class ContentUpdateMapper implements FormDataMapperInterface
                 'fieldDefinition' => $fieldDef,
                 'field' => $field,
                 'value' => $shouldUseCurrentFieldValue
-                        ? $mappedCurrentFields[$fieldDef->identifier]->value
-                        : $field->value,
+                    ? $mappedCurrentFields[$fieldDef->identifier]->value
+                    : $field->value,
             ]));
         }
 

--- a/tests/lib/Data/Mapper/ContentUpdateMapperTest.php
+++ b/tests/lib/Data/Mapper/ContentUpdateMapperTest.php
@@ -39,7 +39,58 @@ final class ContentUpdateMapperTest extends TestCase
                 'value' => $expectedShortName = 'Nontranslateable short name',
             ]),
         ];
-        $content = new Content([
+
+        $newName = 'GER name';
+        $newShortName = '';
+        $content = $this->getContent($newName, $newShortName, 'ger-DE');
+
+        $data = (new ContentUpdateMapper())->mapToFormData($content, [
+            'languageCode' => 'ger-DE',
+            'contentType' => $this->getContentType(),
+            'currentFields' => $currentFields,
+        ]);
+
+        $fieldsData = $data->fieldsData;
+
+        self::assertSame($newName, $fieldsData['name']->value);
+        self::assertSame($expectedShortName, $fieldsData['short_name']->value);
+    }
+
+    public function testMapToFormDataWithTheSameLanguage(): void
+    {
+        $currentFields = [
+            new APIField([
+                'fieldDefIdentifier' => 'name',
+                'fieldTypeIdentifier' => 'ezstring',
+                'languageCode' => 'eng-GB',
+                'value' => 'Name',
+            ]),
+            new APIField([
+                'fieldDefIdentifier' => 'short_name',
+                'fieldTypeIdentifier' => 'ezstring',
+                'languageCode' => 'eng-GB',
+                'value' => 'Short name',
+            ]),
+        ];
+
+        $newName = 'New name';
+        $newShortName = 'New short name';
+        $content = $this->getContent($newName, $newShortName, 'eng-GB');
+
+        $data = (new ContentUpdateMapper())->mapToFormData($content, [
+            'languageCode' => 'eng-GB',
+            'contentType' => $this->getContentType(),
+            'currentFields' => $currentFields,
+        ]);
+
+        $fieldsData = $data->fieldsData;
+
+        self::assertSame($newName, $fieldsData['name']->value);
+        self::assertSame($newShortName, $fieldsData['short_name']->value);
+    }
+
+    private function getContent(string $name, string $shortName, string $languageCode): Content {
+        return new Content([
             'versionInfo' => new VersionInfo([
                 'contentInfo' => new ContentInfo([
                     'remoteId' => 'foo',
@@ -63,46 +114,40 @@ final class ContentUpdateMapperTest extends TestCase
                     ]),
                 ]),
             ]),
-            'contentType' => $contentType = new ContentType([
-                'identifier' => 'folder',
-                'fieldDefinitions' => new FieldDefinitionCollection([
-                    new FieldDefinition([
-                        'identifier' => 'name',
-                        'isTranslatable' => true,
-                        'defaultValue' => '',
-                    ]),
-                    new FieldDefinition([
-                        'identifier' => 'short_name',
-                        'isTranslatable' => false,
-                        'defaultValue' => '',
-                    ]),
-                ]),
-            ]),
+            'contentType' => $this->getContentType(),
             'internalFields' => [
                 new APIField([
                     'fieldDefIdentifier' => 'name',
                     'fieldTypeIdentifier' => 'ezstring',
-                    'languageCode' => 'ger-DE',
-                    'value' => $expectedName = 'GER name',
+                    'languageCode' => $languageCode,
+                    'value' => $name,
                 ]),
                 new APIField([
                     'fieldDefIdentifier' => 'short_name',
                     'fieldTypeIdentifier' => 'ezstring',
-                    'languageCode' => 'ger-DE',
-                    'value' => '',
+                    'languageCode' => $languageCode,
+                    'value' => $shortName,
                 ]),
             ],
         ]);
+    }
 
-        $data = (new ContentUpdateMapper())->mapToFormData($content, [
-            'languageCode' => 'ger-DE',
-            'contentType' => $contentType,
-            'currentFields' => $currentFields,
+    private function getContentType(): ContentType
+    {
+        return new ContentType([
+            'identifier' => 'folder',
+            'fieldDefinitions' => new FieldDefinitionCollection([
+                new FieldDefinition([
+                    'identifier' => 'name',
+                    'isTranslatable' => true,
+                    'defaultValue' => '',
+                ]),
+                new FieldDefinition([
+                    'identifier' => 'short_name',
+                    'isTranslatable' => false,
+                    'defaultValue' => '',
+                ]),
+            ]),
         ]);
-
-        $fieldsData = $data->fieldsData;
-
-        self::assertSame($expectedName, $fieldsData['name']->value);
-        self::assertSame($expectedShortName, $fieldsData['short_name']->value);
     }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-6495](https://issues.ibexa.co/browse/IBX-6495)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

An additional check was added to ensure that saving new non-translatable values in the same language as a main language won't be reverted.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
